### PR TITLE
Add base data source ABC, registry, and stub connectors

### DIFF
--- a/src/data_sources/__init__.py
+++ b/src/data_sources/__init__.py
@@ -1,0 +1,65 @@
+"""Data source connectors and registry."""
+
+from src.data_sources.base import BaseDataSource
+
+# Registry mapping type strings to connector classes.
+# Each connector module registers itself when imported.
+_REGISTRY: dict[str, type[BaseDataSource]] = {}
+
+
+def register(type_name: str):
+    """Decorator to register a data source connector class."""
+
+    def decorator(cls: type[BaseDataSource]):
+        _REGISTRY[type_name] = cls
+        return cls
+
+    return decorator
+
+
+def get_data_source(config: dict) -> BaseDataSource:
+    """Factory function to instantiate a data source connector by type name.
+
+    Args:
+        config: Dict with at least a 'type' key and any source-specific fields.
+
+    Returns:
+        An instance of the appropriate BaseDataSource subclass.
+
+    Raises:
+        ValueError: If the type is unknown or not registered.
+    """
+    source_type = config.get("type")
+    if not source_type:
+        raise ValueError("Data source config missing 'type' field")
+
+    # Lazy import connectors to populate registry
+    _ensure_registered()
+
+    cls = _REGISTRY.get(source_type)
+    if cls is None:
+        available = ", ".join(sorted(_REGISTRY.keys()))
+        raise ValueError(
+            f"Unknown data source type '{source_type}'. "
+            f"Available types: {available}"
+        )
+
+    return cls(config)
+
+
+def _ensure_registered():
+    """Import all connector modules to trigger registration."""
+    if _REGISTRY:
+        return
+
+    # Import each connector module — their @register decorators populate _REGISTRY
+    from src.data_sources import (  # noqa: F401
+        local_pdf,
+        local_txt,
+        local_csv,
+        gdrive,
+        s3,
+        notion,
+        web,
+        huggingface,
+    )

--- a/src/data_sources/base.py
+++ b/src/data_sources/base.py
@@ -1,0 +1,45 @@
+"""Abstract base class for all data source connectors."""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from langchain_core.documents import Document
+
+
+class BaseDataSource(ABC):
+    """Base class that all data source connectors must implement.
+
+    Each connector loads documents from a specific source (local files,
+    cloud storage, APIs, etc.) and returns them as LangChain Document objects.
+    """
+
+    def __init__(self, config: dict):
+        self.config = config
+
+    @abstractmethod
+    def load(self) -> List[Document]:
+        """Load documents from this data source.
+
+        Returns a list of LangChain Document objects. Every document must have:
+        - page_content: the text content
+        - metadata with at least: source, source_type, file_name (if applicable)
+        """
+
+    @abstractmethod
+    def validate_config(self) -> bool:
+        """Validate that all required config fields are present.
+
+        Returns True if valid.
+        Raises ValueError with a clear message if something is missing.
+        """
+
+    @abstractmethod
+    def health_check(self) -> bool:
+        """Check connectivity and access before the main run starts.
+
+        For local sources: checks if the folder exists and has files.
+        For remote sources: checks credentials and connectivity.
+
+        Returns True if healthy.
+        Raises ConnectionError or RuntimeError with a clear message on failure.
+        """

--- a/src/data_sources/gdrive.py
+++ b/src/data_sources/gdrive.py
@@ -1,0 +1,19 @@
+"""gdrive data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("gdrive")
+class GdriveDataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("gdrive connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("gdrive connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("gdrive connector not yet implemented")

--- a/src/data_sources/huggingface.py
+++ b/src/data_sources/huggingface.py
@@ -1,0 +1,19 @@
+"""huggingface data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("huggingface")
+class HuggingFaceDataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("huggingface connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("huggingface connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("huggingface connector not yet implemented")

--- a/src/data_sources/local_csv.py
+++ b/src/data_sources/local_csv.py
@@ -1,0 +1,19 @@
+"""local_csv data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("local_csv")
+class LocalCsvDataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("local_csv connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("local_csv connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("local_csv connector not yet implemented")

--- a/src/data_sources/local_pdf.py
+++ b/src/data_sources/local_pdf.py
@@ -1,0 +1,19 @@
+"""local_pdf data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("local_pdf")
+class LocalPdfDataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("local_pdf connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("local_pdf connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("local_pdf connector not yet implemented")

--- a/src/data_sources/local_txt.py
+++ b/src/data_sources/local_txt.py
@@ -1,0 +1,19 @@
+"""local_txt data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("local_txt")
+class LocalTxtDataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("local_txt connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("local_txt connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("local_txt connector not yet implemented")

--- a/src/data_sources/notion.py
+++ b/src/data_sources/notion.py
@@ -1,0 +1,19 @@
+"""notion data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("notion")
+class NotionDataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("notion connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("notion connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("notion connector not yet implemented")

--- a/src/data_sources/s3.py
+++ b/src/data_sources/s3.py
@@ -1,0 +1,19 @@
+"""s3 data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("s3")
+class S3DataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("s3 connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("s3 connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("s3 connector not yet implemented")

--- a/src/data_sources/web.py
+++ b/src/data_sources/web.py
@@ -1,0 +1,19 @@
+"""web data source connector — stub to be implemented."""
+
+from typing import List
+from langchain_core.documents import Document
+from src.data_sources import register
+from src.data_sources.base import BaseDataSource
+
+
+@register("web")
+class WebDataSource(BaseDataSource):
+
+    def load(self) -> List[Document]:
+        raise NotImplementedError("web connector not yet implemented")
+
+    def validate_config(self) -> bool:
+        raise NotImplementedError("web connector not yet implemented")
+
+    def health_check(self) -> bool:
+        raise NotImplementedError("web connector not yet implemented")

--- a/tests/test_data_sources/test_registry.py
+++ b/tests/test_data_sources/test_registry.py
@@ -1,0 +1,71 @@
+"""Tests for data source base class and registry."""
+
+import pytest
+from langchain_core.documents import Document
+
+from src.data_sources.base import BaseDataSource
+from src.data_sources import get_data_source, _REGISTRY, _ensure_registered
+
+
+class TestBaseDataSource:
+    def test_cannot_instantiate_abc(self):
+        """BaseDataSource is abstract and cannot be instantiated."""
+        with pytest.raises(TypeError):
+            BaseDataSource(config={})
+
+    def test_subclass_must_implement_all_methods(self):
+        """A subclass that doesn't implement all methods can't be instantiated."""
+
+        class IncompleteSource(BaseDataSource):
+            def load(self):
+                return []
+
+        with pytest.raises(TypeError):
+            IncompleteSource(config={})
+
+
+class TestRegistry:
+    def test_all_connector_types_registered(self):
+        """All expected connector types are in the registry."""
+        _ensure_registered()
+
+        expected_types = {
+            "local_pdf",
+            "local_txt",
+            "local_csv",
+            "gdrive",
+            "s3",
+            "notion",
+            "web",
+            "huggingface",
+        }
+        assert expected_types == set(_REGISTRY.keys())
+
+    def test_get_data_source_returns_correct_type(self):
+        """get_data_source returns an instance of the correct connector."""
+        source = get_data_source({"type": "local_pdf", "path": "data/pdfs/"})
+        assert isinstance(source, BaseDataSource)
+        assert source.config["type"] == "local_pdf"
+
+    def test_get_data_source_unknown_type(self):
+        """get_data_source raises ValueError for unknown types."""
+        with pytest.raises(ValueError, match="Unknown data source type 'nonexistent'"):
+            get_data_source({"type": "nonexistent"})
+
+    def test_get_data_source_missing_type(self):
+        """get_data_source raises ValueError when type is missing."""
+        with pytest.raises(ValueError, match="missing 'type' field"):
+            get_data_source({})
+
+    def test_stubs_raise_not_implemented(self):
+        """Stub connectors raise NotImplementedError for all methods."""
+        source = get_data_source({"type": "local_pdf", "path": "data/pdfs/"})
+
+        with pytest.raises(NotImplementedError):
+            source.load()
+
+        with pytest.raises(NotImplementedError):
+            source.validate_config()
+
+        with pytest.raises(NotImplementedError):
+            source.health_check()


### PR DESCRIPTION
## Summary
- `BaseDataSource` abstract base class with `load()`, `validate_config()`, `health_check()` methods
- Registry pattern with `@register` decorator and `get_data_source()` factory function
- Stub implementations for all 8 connector types: local_pdf, local_txt, local_csv, gdrive, s3, notion, web, huggingface
- Updated langchain import to `langchain_core.documents` (v0.3+ compatible)

## Test plan
- [x] 7 tests pass (`pytest tests/test_data_sources/test_registry.py`)
- [x] ABC cannot be instantiated directly
- [x] Incomplete subclass raises TypeError
- [x] All 8 connector types registered
- [x] Factory returns correct type and handles unknown/missing types
- [x] Stubs raise NotImplementedError

Closes #4