### PR TITLE
Implement local_pdf data source connector

### DIFF
--- a/src/data_sources/local_pdf.py
+++ b/src/data_sources/local_pdf.py
@@ -1,19 +1,116 @@
-"""local_pdf data source connector — stub to be implemented."""
+"""Local PDF data source connector.
 
+Reads PDF files from a configured directory using PyMuPDF (primary)
+with pdfplumber as a fallback parser.
+"""
+
+import logging
+from pathlib import Path
 from typing import List
+
 from langchain_core.documents import Document
+
 from src.data_sources import register
 from src.data_sources.base import BaseDataSource
+
+logger = logging.getLogger(__name__)
 
 
 @register("local_pdf")
 class LocalPdfDataSource(BaseDataSource):
 
-    def load(self) -> List[Document]:
-        raise NotImplementedError("local_pdf connector not yet implemented")
-
     def validate_config(self) -> bool:
-        raise NotImplementedError("local_pdf connector not yet implemented")
+        path = self.config.get("path")
+        if not path:
+            raise ValueError("local_pdf config missing required 'path' field")
+        return True
 
     def health_check(self) -> bool:
-        raise NotImplementedError("local_pdf connector not yet implemented")
+        self.validate_config()
+        path = Path(self.config["path"])
+        if not path.exists():
+            raise RuntimeError(f"PDF directory does not exist: {path}")
+        if not path.is_dir():
+            raise RuntimeError(f"PDF path is not a directory: {path}")
+        pdf_files = list(path.glob("*.pdf"))
+        if not pdf_files:
+            raise RuntimeError(f"No PDF files found in: {path}")
+        logger.info("health_check passed: %d PDF files in %s", len(pdf_files), path)
+        return True
+
+    def load(self) -> List[Document]:
+        self.validate_config()
+        path = Path(self.config["path"])
+        documents: List[Document] = []
+
+        pdf_files = sorted(path.glob("*.pdf"))
+        if not pdf_files:
+            logger.warning("No PDF files found in %s", path)
+            return documents
+
+        for pdf_path in pdf_files:
+            try:
+                docs = self._load_with_pymupdf(pdf_path)
+                documents.extend(docs)
+            except Exception as e:
+                logger.warning(
+                    "PyMuPDF failed on %s (%s), trying pdfplumber", pdf_path.name, e
+                )
+                try:
+                    docs = self._load_with_pdfplumber(pdf_path)
+                    documents.extend(docs)
+                except Exception as e2:
+                    logger.error(
+                        "Both parsers failed on %s: %s", pdf_path.name, e2
+                    )
+
+        logger.info("Loaded %d document pages from %d PDF files", len(documents), len(pdf_files))
+        return documents
+
+    def _load_with_pymupdf(self, pdf_path: Path) -> List[Document]:
+        import fitz
+
+        docs: List[Document] = []
+        doc = fitz.open(str(pdf_path))
+        try:
+            for page_num in range(len(doc)):
+                page = doc[page_num]
+                text = page.get_text()
+                if text.strip():
+                    docs.append(
+                        Document(
+                            page_content=text,
+                            metadata={
+                                "source": str(pdf_path),
+                                "source_type": "local_pdf",
+                                "file_name": pdf_path.name,
+                                "page_number": page_num + 1,
+                                "total_pages": len(doc),
+                            },
+                        )
+                    )
+        finally:
+            doc.close()
+        return docs
+
+    def _load_with_pdfplumber(self, pdf_path: Path) -> List[Document]:
+        import pdfplumber
+
+        docs: List[Document] = []
+        with pdfplumber.open(str(pdf_path)) as pdf:
+            for page_num, page in enumerate(pdf.pages):
+                text = page.extract_text()
+                if text and text.strip():
+                    docs.append(
+                        Document(
+                            page_content=text,
+                            metadata={
+                                "source": str(pdf_path),
+                                "source_type": "local_pdf",
+                                "file_name": pdf_path.name,
+                                "page_number": page_num + 1,
+                                "total_pages": len(pdf.pages),
+                            },
+                        )
+                    )
+        return docs

--- a/tests/test_data_sources/test_local_pdf.py
+++ b/tests/test_data_sources/test_local_pdf.py
@@ -1,0 +1,109 @@
+"""Tests for local_pdf data source connector."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from src.data_sources.local_pdf import LocalPdfDataSource
+
+
+@pytest.fixture
+def pdf_dir(tmp_path):
+    """Create a temp dir with a dummy PDF file."""
+    # Create a minimal valid PDF using PyMuPDF
+    import fitz
+
+    pdf_path = tmp_path / "test.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    text_point = fitz.Point(72, 72)
+    page.insert_text(text_point, "Hello from page 1")
+    page2 = doc.new_page()
+    page2.insert_text(text_point, "Hello from page 2")
+    doc.save(str(pdf_path))
+    doc.close()
+    return tmp_path
+
+
+@pytest.fixture
+def source(pdf_dir):
+    return LocalPdfDataSource({"type": "local_pdf", "path": str(pdf_dir)})
+
+
+class TestValidateConfig:
+    def test_valid_config(self, source):
+        assert source.validate_config() is True
+
+    def test_missing_path(self):
+        src = LocalPdfDataSource({"type": "local_pdf"})
+        with pytest.raises(ValueError, match="missing required 'path'"):
+            src.validate_config()
+
+
+class TestHealthCheck:
+    def test_healthy(self, source):
+        assert source.health_check() is True
+
+    def test_nonexistent_dir(self, tmp_path):
+        src = LocalPdfDataSource({"type": "local_pdf", "path": str(tmp_path / "nope")})
+        with pytest.raises(RuntimeError, match="does not exist"):
+            src.health_check()
+
+    def test_empty_dir(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        src = LocalPdfDataSource({"type": "local_pdf", "path": str(empty)})
+        with pytest.raises(RuntimeError, match="No PDF files found"):
+            src.health_check()
+
+    def test_not_a_directory(self, tmp_path):
+        file = tmp_path / "notadir.txt"
+        file.write_text("hi")
+        src = LocalPdfDataSource({"type": "local_pdf", "path": str(file)})
+        with pytest.raises(RuntimeError, match="not a directory"):
+            src.health_check()
+
+
+class TestLoad:
+    def test_loads_pages(self, source):
+        docs = source.load()
+        assert len(docs) == 2
+        assert "Hello from page 1" in docs[0].page_content
+        assert "Hello from page 2" in docs[1].page_content
+
+    def test_metadata(self, source):
+        docs = source.load()
+        meta = docs[0].metadata
+        assert meta["source_type"] == "local_pdf"
+        assert meta["file_name"] == "test.pdf"
+        assert meta["page_number"] == 1
+        assert meta["total_pages"] == 2
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        src = LocalPdfDataSource({"type": "local_pdf", "path": str(empty)})
+        assert src.load() == []
+
+    def test_fallback_to_pdfplumber(self, source, pdf_dir):
+        """If PyMuPDF fails, pdfplumber is used as fallback."""
+        with patch.object(
+            source, "_load_with_pymupdf", side_effect=Exception("pymupdf broke")
+        ) as mock_pymupdf:
+            with patch.object(
+                source, "_load_with_pdfplumber", return_value=[]
+            ) as mock_plumber:
+                source.load()
+                mock_pymupdf.assert_called()
+                mock_plumber.assert_called()
+
+    def test_both_parsers_fail_skips_file(self, source):
+        """If both parsers fail, the file is skipped with no crash."""
+        with patch.object(
+            source, "_load_with_pymupdf", side_effect=Exception("fail1")
+        ):
+            with patch.object(
+                source, "_load_with_pdfplumber", side_effect=Exception("fail2")
+            ):
+                docs = source.load()
+                assert docs == []


### PR DESCRIPTION
## Summary
- PyMuPDF as primary PDF parser with pdfplumber fallback
- Page-by-page text extraction with metadata (source, source_type, file_name, page_number, total_pages)
- Graceful error handling: skips files where both parsers fail
- Config validation and health check implementations

## Test plan
- [x] 11 tests pass (`pytest tests/test_data_sources/test_local_pdf.py`)
- [x] Config validation: valid config, missing path
- [x] Health check: healthy dir, nonexistent dir, empty dir, not-a-directory
- [x] Loading: page extraction, metadata correctness, empty dir, pdfplumber fallback, both-parsers-fail skip

Closes #5