### PR TITLE
Implement local_txt data source connector

### DIFF
--- a/src/data_sources/local_txt.py
+++ b/src/data_sources/local_txt.py
@@ -1,19 +1,79 @@
-"""local_txt data source connector — stub to be implemented."""
+"""Local TXT data source connector.
 
+Reads plain text files from a configured directory with automatic
+encoding detection via chardet.
+"""
+
+import logging
+from pathlib import Path
 from typing import List
+
+import chardet
 from langchain_core.documents import Document
+
 from src.data_sources import register
 from src.data_sources.base import BaseDataSource
+
+logger = logging.getLogger(__name__)
 
 
 @register("local_txt")
 class LocalTxtDataSource(BaseDataSource):
 
-    def load(self) -> List[Document]:
-        raise NotImplementedError("local_txt connector not yet implemented")
-
     def validate_config(self) -> bool:
-        raise NotImplementedError("local_txt connector not yet implemented")
+        path = self.config.get("path")
+        if not path:
+            raise ValueError("local_txt config missing required 'path' field")
+        return True
 
     def health_check(self) -> bool:
-        raise NotImplementedError("local_txt connector not yet implemented")
+        self.validate_config()
+        path = Path(self.config["path"])
+        if not path.exists():
+            raise RuntimeError(f"TXT directory does not exist: {path}")
+        if not path.is_dir():
+            raise RuntimeError(f"TXT path is not a directory: {path}")
+        txt_files = list(path.glob("*.txt"))
+        if not txt_files:
+            raise RuntimeError(f"No .txt files found in: {path}")
+        logger.info("health_check passed: %d TXT files in %s", len(txt_files), path)
+        return True
+
+    def load(self) -> List[Document]:
+        self.validate_config()
+        path = Path(self.config["path"])
+        documents: List[Document] = []
+
+        txt_files = sorted(path.glob("*.txt"))
+        if not txt_files:
+            logger.warning("No .txt files found in %s", path)
+            return documents
+
+        for txt_path in txt_files:
+            try:
+                text = self._read_with_detected_encoding(txt_path)
+                if text.strip():
+                    documents.append(
+                        Document(
+                            page_content=text,
+                            metadata={
+                                "source": str(txt_path),
+                                "source_type": "local_txt",
+                                "file_name": txt_path.name,
+                                "char_count": len(text),
+                            },
+                        )
+                    )
+            except Exception as e:
+                logger.error("Failed to read %s: %s", txt_path.name, e)
+
+        logger.info("Loaded %d documents from %d TXT files", len(documents), len(txt_files))
+        return documents
+
+    def _read_with_detected_encoding(self, file_path: Path) -> str:
+        raw = file_path.read_bytes()
+        if not raw:
+            return ""
+        detected = chardet.detect(raw)
+        encoding = detected.get("encoding") or "utf-8"
+        return raw.decode(encoding)

--- a/tests/test_data_sources/test_local_txt.py
+++ b/tests/test_data_sources/test_local_txt.py
@@ -1,0 +1,90 @@
+"""Tests for local_txt data source connector."""
+
+import pytest
+from pathlib import Path
+
+from src.data_sources.local_txt import LocalTxtDataSource
+
+
+@pytest.fixture
+def txt_dir(tmp_path):
+    """Create a temp dir with sample text files."""
+    (tmp_path / "hello.txt").write_text("Hello world", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("Some notes here", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def source(txt_dir):
+    return LocalTxtDataSource({"type": "local_txt", "path": str(txt_dir)})
+
+
+class TestValidateConfig:
+    def test_valid_config(self, source):
+        assert source.validate_config() is True
+
+    def test_missing_path(self):
+        src = LocalTxtDataSource({"type": "local_txt"})
+        with pytest.raises(ValueError, match="missing required 'path'"):
+            src.validate_config()
+
+
+class TestHealthCheck:
+    def test_healthy(self, source):
+        assert source.health_check() is True
+
+    def test_nonexistent_dir(self, tmp_path):
+        src = LocalTxtDataSource({"type": "local_txt", "path": str(tmp_path / "nope")})
+        with pytest.raises(RuntimeError, match="does not exist"):
+            src.health_check()
+
+    def test_empty_dir(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        src = LocalTxtDataSource({"type": "local_txt", "path": str(empty)})
+        with pytest.raises(RuntimeError, match="No .txt files found"):
+            src.health_check()
+
+    def test_not_a_directory(self, tmp_path):
+        file = tmp_path / "notadir.txt"
+        file.write_text("hi")
+        src = LocalTxtDataSource({"type": "local_txt", "path": str(file)})
+        with pytest.raises(RuntimeError, match="not a directory"):
+            src.health_check()
+
+
+class TestLoad:
+    def test_loads_files(self, source):
+        docs = source.load()
+        assert len(docs) == 2
+        contents = {d.page_content for d in docs}
+        assert "Hello world" in contents
+        assert "Some notes here" in contents
+
+    def test_metadata(self, source):
+        docs = source.load()
+        doc = next(d for d in docs if d.metadata["file_name"] == "hello.txt")
+        assert doc.metadata["source_type"] == "local_txt"
+        assert doc.metadata["char_count"] == len("Hello world")
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        src = LocalTxtDataSource({"type": "local_txt", "path": str(empty)})
+        assert src.load() == []
+
+    def test_skips_whitespace_only_files(self, tmp_path):
+        (tmp_path / "blank.txt").write_text("   \n\n  ", encoding="utf-8")
+        src = LocalTxtDataSource({"type": "local_txt", "path": str(tmp_path)})
+        assert src.load() == []
+
+    def test_detects_encoding(self, tmp_path):
+        """Files with non-UTF-8 encoding are read without crashing."""
+        # Use a longer string so chardet has enough signal to detect encoding.
+        text = "Le café est très bon. Ça coûte cinq euros pour un résumé complet."
+        (tmp_path / "latin.txt").write_bytes(text.encode("latin-1"))
+        src = LocalTxtDataSource({"type": "local_txt", "path": str(tmp_path)})
+        docs = src.load()
+        assert len(docs) == 1
+        # The file should be readable (not raise) and contain recognizable content
+        assert "caf" in docs[0].page_content


### PR DESCRIPTION
## Summary
- Reads all `.txt` files from configured directory
- Automatic encoding detection via chardet (handles non-UTF-8 files)
- Metadata includes source, source_type, file_name, char_count
- Skips whitespace-only files, logs errors for unreadable files

## Test plan
- [x] 11 tests pass (`pytest tests/test_data_sources/test_local_txt.py`)
- [x] Config validation, health checks (missing dir, empty dir, not-a-dir)
- [x] File loading, metadata, whitespace-only skip, encoding detection

Closes #6