### PR TITLE
Implement all remote data source connectors

### DIFF
--- a/src/data_sources/__init__.py
+++ b/src/data_sources/__init__.py
@@ -47,9 +47,12 @@ def get_data_source(config: dict) -> BaseDataSource:
     return cls(config)
 
 
+_ALL_CONNECTOR_MODULES = ("local_pdf", "local_txt", "local_csv", "gdrive", "s3", "notion", "web", "huggingface")
+
+
 def _ensure_registered():
     """Import all connector modules to trigger registration."""
-    if _REGISTRY:
+    if len(_REGISTRY) >= len(_ALL_CONNECTOR_MODULES):
         return
 
     # Import each connector module — their @register decorators populate _REGISTRY

--- a/src/data_sources/gdrive.py
+++ b/src/data_sources/gdrive.py
@@ -1,19 +1,162 @@
-"""gdrive data source connector — stub to be implemented."""
+"""Google Drive data source connector.
 
+Reads PDF and DOCX files from a configured Google Drive folder
+using the Drive API v3 with OAuth2 credentials.
+"""
+
+import io
+import logging
+from pathlib import Path
 from typing import List
+
 from langchain_core.documents import Document
+
 from src.data_sources import register
 from src.data_sources.base import BaseDataSource
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_MIMES = {
+    "application/pdf": "pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+}
 
 
 @register("gdrive")
 class GdriveDataSource(BaseDataSource):
 
-    def load(self) -> List[Document]:
-        raise NotImplementedError("gdrive connector not yet implemented")
-
     def validate_config(self) -> bool:
-        raise NotImplementedError("gdrive connector not yet implemented")
+        folder_id = self.config.get("folder_id")
+        if not folder_id:
+            raise ValueError("gdrive config missing required 'folder_id' field")
+        creds_path = self.config.get("credentials_path", ".secrets/credentials.json")
+        if not Path(creds_path).exists():
+            raise ValueError(
+                f"Google Drive credentials not found at '{creds_path}'. "
+                "Place your OAuth2 credentials.json in .secrets/"
+            )
+        return True
 
     def health_check(self) -> bool:
-        raise NotImplementedError("gdrive connector not yet implemented")
+        self.validate_config()
+        service = self._build_service()
+        folder_id = self.config["folder_id"]
+        try:
+            service.files().list(
+                q=f"'{folder_id}' in parents and trashed=false",
+                pageSize=1,
+                fields="files(id)",
+            ).execute()
+        except Exception as e:
+            raise ConnectionError(f"Cannot access Google Drive folder '{folder_id}': {e}")
+        logger.info("health_check passed: Google Drive folder %s accessible", folder_id)
+        return True
+
+    def load(self) -> List[Document]:
+        self.validate_config()
+        service = self._build_service()
+        folder_id = self.config["folder_id"]
+        documents: List[Document] = []
+
+        # List files in folder
+        query = f"'{folder_id}' in parents and trashed=false"
+        results = service.files().list(
+            q=query,
+            pageSize=100,
+            fields="files(id, name, mimeType, modifiedTime)",
+        ).execute()
+        files = results.get("files", [])
+
+        for file_info in files:
+            mime = file_info.get("mimeType", "")
+            if mime not in SUPPORTED_MIMES:
+                logger.debug("Skipping unsupported file type: %s (%s)", file_info["name"], mime)
+                continue
+
+            try:
+                content = service.files().get_media(fileId=file_info["id"]).execute()
+                file_type = SUPPORTED_MIMES[mime]
+
+                if file_type == "pdf":
+                    docs = self._extract_pdf(content, file_info)
+                elif file_type == "docx":
+                    docs = self._extract_docx(content, file_info)
+                else:
+                    continue
+
+                documents.extend(docs)
+            except Exception as e:
+                logger.error("Failed to process %s: %s", file_info["name"], e)
+
+        logger.info("Loaded %d documents from Google Drive folder %s", len(documents), folder_id)
+        return documents
+
+    def _build_service(self):
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+
+        creds_path = self.config.get("credentials_path", ".secrets/credentials.json")
+        token_path = self.config.get("token_path", ".secrets/token.json")
+
+        creds = None
+        if Path(token_path).exists():
+            creds = Credentials.from_authorized_user_file(
+                token_path, ["https://www.googleapis.com/auth/drive.readonly"]
+            )
+
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                from google.auth.transport.requests import Request
+                creds.refresh(Request())
+            else:
+                from google_auth_oauthlib.flow import InstalledAppFlow
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    creds_path, ["https://www.googleapis.com/auth/drive.readonly"]
+                )
+                creds = flow.run_local_server(port=0)
+            Path(token_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(token_path).write_text(creds.to_json())
+
+        return build("drive", "v3", credentials=creds)
+
+    def _extract_pdf(self, content: bytes, file_info: dict) -> List[Document]:
+        import fitz
+
+        docs: List[Document] = []
+        doc = fitz.open(stream=content, filetype="pdf")
+        try:
+            for page_num in range(len(doc)):
+                text = doc[page_num].get_text()
+                if text.strip():
+                    docs.append(Document(
+                        page_content=text,
+                        metadata={
+                            "source": f"gdrive://{file_info['id']}",
+                            "source_type": "gdrive",
+                            "file_name": file_info["name"],
+                            "drive_file_id": file_info["id"],
+                            "last_modified": file_info.get("modifiedTime", ""),
+                            "page_number": page_num + 1,
+                        },
+                    ))
+        finally:
+            doc.close()
+        return docs
+
+    def _extract_docx(self, content: bytes, file_info: dict) -> List[Document]:
+        from docx import Document as DocxDocument
+
+        doc = DocxDocument(io.BytesIO(content))
+        text = "\n".join(p.text for p in doc.paragraphs if p.text.strip())
+        if not text.strip():
+            return []
+        return [Document(
+            page_content=text,
+            metadata={
+                "source": f"gdrive://{file_info['id']}",
+                "source_type": "gdrive",
+                "file_name": file_info["name"],
+                "drive_file_id": file_info["id"],
+                "last_modified": file_info.get("modifiedTime", ""),
+            },
+        )]

--- a/src/data_sources/huggingface.py
+++ b/src/data_sources/huggingface.py
@@ -1,19 +1,159 @@
-"""huggingface data source connector — stub to be implemented."""
+"""HuggingFace datasets data source connector.
 
-from typing import List
+Loads SQuAD and HotpotQA datasets, extracting both documents and QA pairs
+for evaluation.
+"""
+
+import logging
+from typing import List, Optional
+
 from langchain_core.documents import Document
+
 from src.data_sources import register
 from src.data_sources.base import BaseDataSource
+
+logger = logging.getLogger(__name__)
 
 
 @register("huggingface")
 class HuggingFaceDataSource(BaseDataSource):
 
-    def load(self) -> List[Document]:
-        raise NotImplementedError("huggingface connector not yet implemented")
-
     def validate_config(self) -> bool:
-        raise NotImplementedError("huggingface connector not yet implemented")
+        dataset_name = self.config.get("dataset_name")
+        if not dataset_name:
+            raise ValueError("huggingface config missing required 'dataset_name' field")
+        split = self.config.get("split")
+        if not split:
+            raise ValueError("huggingface config missing required 'split' field")
+        return True
 
     def health_check(self) -> bool:
-        raise NotImplementedError("huggingface connector not yet implemented")
+        self.validate_config()
+        from datasets import load_dataset_builder
+
+        dataset_name = self.config["dataset_name"]
+        try:
+            load_dataset_builder(dataset_name)
+        except Exception as e:
+            raise ConnectionError(f"Cannot access HuggingFace dataset '{dataset_name}': {e}")
+        logger.info("health_check passed: HuggingFace dataset %s accessible", dataset_name)
+        return True
+
+    def load(self) -> List[Document]:
+        """Load documents only (without QA pairs)."""
+        docs, _ = self.load_with_qa()
+        return docs
+
+    def load_with_qa(self) -> tuple[List[Document], List[dict]]:
+        """Load documents and QA pairs from the dataset.
+
+        Returns:
+            Tuple of (documents, qa_pairs).
+        """
+        self.validate_config()
+        from datasets import load_dataset
+
+        dataset_name = self.config["dataset_name"]
+        split = self.config["split"]
+        sample_size = self.config.get("sample_size")
+
+        ds = load_dataset(dataset_name, split=split)
+
+        if sample_size and sample_size < len(ds):
+            ds = ds.select(range(sample_size))
+
+        if "squad" in dataset_name.lower():
+            return self._process_squad(ds, dataset_name, split)
+        elif "hotpot" in dataset_name.lower():
+            return self._process_hotpotqa(ds, dataset_name, split)
+        else:
+            logger.warning("Unknown dataset format '%s', attempting SQuAD-style extraction", dataset_name)
+            return self._process_squad(ds, dataset_name, split)
+
+    def _process_squad(self, ds, dataset_name: str, split: str) -> tuple[List[Document], List[dict]]:
+        documents: List[Document] = []
+        qa_pairs: List[dict] = []
+        seen_contexts: set[str] = set()
+
+        for i, example in enumerate(ds):
+            context = example.get("context", "")
+            question = example.get("question", "")
+            answers = example.get("answers", {})
+
+            # Extract ground truth answer
+            if isinstance(answers, dict):
+                answer_texts = answers.get("text", [])
+                ground_truth = answer_texts[0] if answer_texts else ""
+            elif isinstance(answers, list):
+                ground_truth = answers[0] if answers else ""
+            else:
+                ground_truth = str(answers)
+
+            # Add context as document (deduplicate)
+            if context and context not in seen_contexts:
+                seen_contexts.add(context)
+                documents.append(Document(
+                    page_content=context,
+                    metadata={
+                        "source": f"huggingface://{dataset_name}",
+                        "source_type": "huggingface",
+                        "dataset_name": dataset_name,
+                        "split": split,
+                        "index": i,
+                    },
+                ))
+
+            # Add QA pair
+            if question:
+                qa_pairs.append({
+                    "question": question,
+                    "ground_truth": ground_truth,
+                })
+
+        logger.info(
+            "Loaded %d documents and %d QA pairs from %s/%s",
+            len(documents), len(qa_pairs), dataset_name, split,
+        )
+        return documents, qa_pairs
+
+    def _process_hotpotqa(self, ds, dataset_name: str, split: str) -> tuple[List[Document], List[dict]]:
+        documents: List[Document] = []
+        qa_pairs: List[dict] = []
+        seen_contexts: set[str] = set()
+
+        for i, example in enumerate(ds):
+            question = example.get("question", "")
+            answer = example.get("answer", "")
+
+            # Supporting facts as documents
+            sentences = example.get("context", {})
+            if isinstance(sentences, dict):
+                titles = sentences.get("title", [])
+                sent_lists = sentences.get("sentences", [])
+                for title, sents in zip(titles, sent_lists):
+                    context = " ".join(sents) if isinstance(sents, list) else str(sents)
+                    if context and context not in seen_contexts:
+                        seen_contexts.add(context)
+                        documents.append(Document(
+                            page_content=context,
+                            metadata={
+                                "source": f"huggingface://{dataset_name}",
+                                "source_type": "huggingface",
+                                "dataset_name": dataset_name,
+                                "split": split,
+                                "index": i,
+                                "title": title,
+                            },
+                        ))
+
+            if question:
+                qa_pairs.append({
+                    "question": question,
+                    "ground_truth": answer,
+                })
+
+        logger.info(
+            "Loaded %d documents and %d QA pairs from %s/%s",
+            len(documents), len(qa_pairs), dataset_name, split,
+        )
+        return documents, qa_pairs

--- a/src/data_sources/notion.py
+++ b/src/data_sources/notion.py
@@ -1,19 +1,187 @@
-"""notion data source connector — stub to be implemented."""
+"""Notion data source connector.
 
+Fetches pages from a Notion database and extracts text content
+from page blocks recursively.
+"""
+
+import logging
+import os
 from typing import List
+
+import requests
 from langchain_core.documents import Document
+
 from src.data_sources import register
 from src.data_sources.base import BaseDataSource
+
+logger = logging.getLogger(__name__)
+
+NOTION_API_URL = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
 
 
 @register("notion")
 class NotionDataSource(BaseDataSource):
 
-    def load(self) -> List[Document]:
-        raise NotImplementedError("notion connector not yet implemented")
-
     def validate_config(self) -> bool:
-        raise NotImplementedError("notion connector not yet implemented")
+        database_id = self.config.get("database_id")
+        if not database_id:
+            raise ValueError("notion config missing required 'database_id' field")
+        if not os.environ.get("NOTION_API_KEY"):
+            raise ValueError(
+                "NOTION_API_KEY environment variable not set. "
+                "Create an integration at https://www.notion.so/my-integrations "
+                "and export NOTION_API_KEY."
+            )
+        return True
 
     def health_check(self) -> bool:
-        raise NotImplementedError("notion connector not yet implemented")
+        self.validate_config()
+        headers = self._headers()
+        database_id = self.config["database_id"]
+        resp = requests.get(
+            f"{NOTION_API_URL}/databases/{database_id}",
+            headers=headers,
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            raise ConnectionError(
+                f"Cannot access Notion database '{database_id}': "
+                f"{resp.status_code} {resp.text[:200]}"
+            )
+        logger.info("health_check passed: Notion database %s accessible", database_id)
+        return True
+
+    def load(self) -> List[Document]:
+        self.validate_config()
+        headers = self._headers()
+        database_id = self.config["database_id"]
+        documents: List[Document] = []
+
+        # Query all pages in the database
+        pages = self._query_database(headers, database_id)
+
+        for page in pages:
+            try:
+                page_id = page["id"]
+                title = self._get_page_title(page)
+                last_edited = page.get("last_edited_time", "")
+
+                # Fetch and extract block content
+                blocks = self._get_blocks(headers, page_id)
+                text = self._extract_text(headers, blocks)
+
+                if text.strip():
+                    documents.append(Document(
+                        page_content=text,
+                        metadata={
+                            "source": f"notion://{page_id}",
+                            "source_type": "notion",
+                            "notion_page_id": page_id,
+                            "title": title,
+                            "last_edited_time": last_edited,
+                        },
+                    ))
+            except Exception as e:
+                logger.error("Failed to process Notion page %s: %s", page.get("id", "?"), e)
+
+        logger.info("Loaded %d documents from Notion database %s", len(documents), database_id)
+        return documents
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {os.environ['NOTION_API_KEY']}",
+            "Notion-Version": NOTION_VERSION,
+            "Content-Type": "application/json",
+        }
+
+    def _query_database(self, headers: dict, database_id: str) -> list:
+        pages = []
+        start_cursor = None
+        while True:
+            body = {}
+            if start_cursor:
+                body["start_cursor"] = start_cursor
+            resp = requests.post(
+                f"{NOTION_API_URL}/databases/{database_id}/query",
+                headers=headers,
+                json=body,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            pages.extend(data.get("results", []))
+            if not data.get("has_more"):
+                break
+            start_cursor = data.get("next_cursor")
+        return pages
+
+    def _get_page_title(self, page: dict) -> str:
+        props = page.get("properties", {})
+        for prop in props.values():
+            if prop.get("type") == "title":
+                title_parts = prop.get("title", [])
+                return "".join(t.get("plain_text", "") for t in title_parts)
+        return "Untitled"
+
+    def _get_blocks(self, headers: dict, block_id: str) -> list:
+        blocks = []
+        start_cursor = None
+        while True:
+            params = {}
+            if start_cursor:
+                params["start_cursor"] = start_cursor
+            resp = requests.get(
+                f"{NOTION_API_URL}/blocks/{block_id}/children",
+                headers=headers,
+                params=params,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            blocks.extend(data.get("results", []))
+            if not data.get("has_more"):
+                break
+            start_cursor = data.get("next_cursor")
+        return blocks
+
+    def _extract_text(self, headers: dict, blocks: list) -> str:
+        parts = []
+        for block in blocks:
+            block_type = block.get("type", "")
+            block_data = block.get(block_type, {})
+
+            # Extract rich text from common block types
+            rich_text = block_data.get("rich_text", [])
+            text = "".join(rt.get("plain_text", "") for rt in rich_text)
+
+            if block_type in ("heading_1", "heading_2", "heading_3"):
+                parts.append(f"\n{'#' * int(block_type[-1])} {text}\n")
+            elif block_type in ("paragraph", "quote", "callout"):
+                if text:
+                    parts.append(text)
+            elif block_type in ("bulleted_list_item", "numbered_list_item"):
+                if text:
+                    parts.append(f"- {text}")
+            elif block_type == "to_do":
+                checked = block_data.get("checked", False)
+                marker = "[x]" if checked else "[ ]"
+                parts.append(f"{marker} {text}")
+            elif block_type == "toggle":
+                if text:
+                    parts.append(text)
+            elif block_type == "code":
+                if text:
+                    parts.append(f"```\n{text}\n```")
+
+            # Recurse into children
+            if block.get("has_children"):
+                try:
+                    children = self._get_blocks(headers, block["id"])
+                    child_text = self._extract_text(headers, children)
+                    if child_text.strip():
+                        parts.append(child_text)
+                except Exception as e:
+                    logger.debug("Failed to get children of block %s: %s", block["id"], e)
+
+        return "\n".join(parts)

--- a/src/data_sources/s3.py
+++ b/src/data_sources/s3.py
@@ -1,19 +1,139 @@
-"""s3 data source connector — stub to be implemented."""
+"""AWS S3 data source connector.
 
+Reads PDF and TXT files from a configured S3 bucket/prefix.
+Uses IAM credentials from environment variables.
+"""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
 from typing import List
+
 from langchain_core.documents import Document
+
 from src.data_sources import register
 from src.data_sources.base import BaseDataSource
+
+logger = logging.getLogger(__name__)
 
 
 @register("s3")
 class S3DataSource(BaseDataSource):
 
-    def load(self) -> List[Document]:
-        raise NotImplementedError("s3 connector not yet implemented")
-
     def validate_config(self) -> bool:
-        raise NotImplementedError("s3 connector not yet implemented")
+        bucket = self.config.get("bucket")
+        if not bucket:
+            raise ValueError("s3 config missing required 'bucket' field")
+        if not os.environ.get("AWS_ACCESS_KEY_ID"):
+            raise ValueError(
+                "AWS_ACCESS_KEY_ID environment variable not set. "
+                "Export it or add it to your .env file."
+            )
+        if not os.environ.get("AWS_SECRET_ACCESS_KEY"):
+            raise ValueError(
+                "AWS_SECRET_ACCESS_KEY environment variable not set. "
+                "Export it or add it to your .env file."
+            )
+        return True
 
     def health_check(self) -> bool:
-        raise NotImplementedError("s3 connector not yet implemented")
+        self.validate_config()
+        client = self._get_client()
+        bucket = self.config["bucket"]
+        try:
+            client.head_bucket(Bucket=bucket)
+        except Exception as e:
+            raise ConnectionError(f"Cannot access S3 bucket '{bucket}': {e}")
+        logger.info("health_check passed: S3 bucket %s accessible", bucket)
+        return True
+
+    def load(self) -> List[Document]:
+        self.validate_config()
+        client = self._get_client()
+        bucket = self.config["bucket"]
+        prefix = self.config.get("prefix", "")
+        documents: List[Document] = []
+
+        paginator = client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith("/"):
+                    continue
+
+                ext = Path(key).suffix.lower()
+                if ext not in (".pdf", ".txt"):
+                    logger.debug("Skipping unsupported file: %s", key)
+                    continue
+
+                try:
+                    docs = self._process_file(client, bucket, obj)
+                    documents.extend(docs)
+                except Exception as e:
+                    logger.error("Failed to process s3://%s/%s: %s", bucket, key, e)
+
+        logger.info("Loaded %d documents from s3://%s/%s", len(documents), bucket, prefix)
+        return documents
+
+    def _get_client(self):
+        import boto3
+        return boto3.client("s3")
+
+    def _process_file(self, client, bucket: str, obj: dict) -> List[Document]:
+        key = obj["Key"]
+        ext = Path(key).suffix.lower()
+
+        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+            tmp_path = tmp.name
+            client.download_file(bucket, key, tmp_path)
+
+        try:
+            if ext == ".pdf":
+                return self._extract_pdf(tmp_path, bucket, obj)
+            elif ext == ".txt":
+                return self._extract_txt(tmp_path, bucket, obj)
+            return []
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    def _extract_pdf(self, file_path: str, bucket: str, obj: dict) -> List[Document]:
+        import fitz
+
+        docs: List[Document] = []
+        doc = fitz.open(file_path)
+        try:
+            for page_num in range(len(doc)):
+                text = doc[page_num].get_text()
+                if text.strip():
+                    docs.append(Document(
+                        page_content=text,
+                        metadata={
+                            "source": f"s3://{bucket}/{obj['Key']}",
+                            "source_type": "s3",
+                            "file_name": Path(obj["Key"]).name,
+                            "s3_key": obj["Key"],
+                            "bucket_name": bucket,
+                            "last_modified": str(obj.get("LastModified", "")),
+                            "page_number": page_num + 1,
+                        },
+                    ))
+        finally:
+            doc.close()
+        return docs
+
+    def _extract_txt(self, file_path: str, bucket: str, obj: dict) -> List[Document]:
+        text = Path(file_path).read_text(encoding="utf-8")
+        if not text.strip():
+            return []
+        return [Document(
+            page_content=text,
+            metadata={
+                "source": f"s3://{bucket}/{obj['Key']}",
+                "source_type": "s3",
+                "file_name": Path(obj["Key"]).name,
+                "s3_key": obj["Key"],
+                "bucket_name": bucket,
+                "last_modified": str(obj.get("LastModified", "")),
+            },
+        )]

--- a/src/data_sources/web.py
+++ b/src/data_sources/web.py
@@ -1,19 +1,107 @@
-"""web data source connector — stub to be implemented."""
+"""Web URL scraper data source connector.
 
+Scrapes configured URLs using BeautifulSoup, extracts main content,
+and respects robots.txt.
+"""
+
+import logging
+from datetime import datetime, timezone
 from typing import List
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import requests
+from bs4 import BeautifulSoup
 from langchain_core.documents import Document
+
 from src.data_sources import register
 from src.data_sources.base import BaseDataSource
+
+logger = logging.getLogger(__name__)
+
+STRIP_TAGS = {"nav", "footer", "sidebar", "script", "style", "header", "aside"}
+DEFAULT_TIMEOUT = 10
 
 
 @register("web")
 class WebDataSource(BaseDataSource):
 
-    def load(self) -> List[Document]:
-        raise NotImplementedError("web connector not yet implemented")
-
     def validate_config(self) -> bool:
-        raise NotImplementedError("web connector not yet implemented")
+        urls = self.config.get("urls")
+        if not urls or not isinstance(urls, list) or len(urls) == 0:
+            raise ValueError("web config missing required 'urls' field (must be a non-empty list)")
+        return True
 
     def health_check(self) -> bool:
-        raise NotImplementedError("web connector not yet implemented")
+        self.validate_config()
+        urls = self.config["urls"]
+        reachable = False
+        for url in urls:
+            try:
+                resp = requests.head(url, timeout=DEFAULT_TIMEOUT, allow_redirects=True)
+                if resp.status_code < 400:
+                    reachable = True
+                    break
+            except Exception:
+                continue
+
+        if not reachable:
+            raise ConnectionError("None of the configured URLs are reachable")
+        logger.info("health_check passed: at least one URL reachable")
+        return True
+
+    def load(self) -> List[Document]:
+        self.validate_config()
+        urls = self.config["urls"]
+        documents: List[Document] = []
+
+        for url in urls:
+            try:
+                if not self._check_robots(url):
+                    logger.warning("robots.txt disallows access to %s, skipping", url)
+                    continue
+
+                resp = requests.get(url, timeout=DEFAULT_TIMEOUT)
+                resp.raise_for_status()
+
+                soup = BeautifulSoup(resp.text, "html.parser")
+                title = soup.title.string.strip() if soup.title and soup.title.string else url
+
+                # Strip unwanted elements
+                for tag_name in STRIP_TAGS:
+                    for tag in soup.find_all(tag_name):
+                        tag.decompose()
+
+                text = soup.get_text(separator="\n", strip=True)
+                if text.strip():
+                    documents.append(Document(
+                        page_content=text,
+                        metadata={
+                            "source": url,
+                            "source_type": "web",
+                            "url": url,
+                            "page_title": title,
+                            "scrape_timestamp": datetime.now(timezone.utc).isoformat(),
+                        },
+                    ))
+            except Exception as e:
+                if "Timeout" in type(e).__name__:
+                    logger.warning("Timeout scraping %s, skipping", url)
+                else:
+                    logger.error("Failed to scrape %s: %s", url, e)
+
+        logger.info("Loaded %d documents from %d URLs", len(documents), len(urls))
+        return documents
+
+    def _check_robots(self, url: str) -> bool:
+        """Check if robots.txt allows scraping the URL."""
+        try:
+            parsed = urlparse(url)
+            robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+            rp = RobotFileParser()
+            rp.set_url(robots_url)
+            rp.read()
+            return rp.can_fetch("*", url)
+        except Exception:
+            # If we can't read robots.txt, allow access
+            return True

--- a/tests/test_data_sources/test_gdrive.py
+++ b/tests/test_data_sources/test_gdrive.py
@@ -1,0 +1,108 @@
+"""Tests for Google Drive data source connector."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.data_sources.gdrive import GdriveDataSource
+
+
+class TestGdriveValidateConfig:
+    def test_missing_folder_id(self):
+        source = GdriveDataSource({"type": "gdrive"})
+        with pytest.raises(ValueError, match="folder_id"):
+            source.validate_config()
+
+    def test_missing_credentials_file(self, tmp_path):
+        source = GdriveDataSource({
+            "type": "gdrive",
+            "folder_id": "abc123",
+            "credentials_path": str(tmp_path / "nonexistent.json"),
+        })
+        with pytest.raises(ValueError, match="credentials not found"):
+            source.validate_config()
+
+    def test_valid_config(self, tmp_path):
+        creds = tmp_path / "credentials.json"
+        creds.write_text("{}")
+        source = GdriveDataSource({
+            "type": "gdrive",
+            "folder_id": "abc123",
+            "credentials_path": str(creds),
+        })
+        assert source.validate_config() is True
+
+
+class TestGdriveLoad:
+    @patch.object(GdriveDataSource, "_build_service")
+    @patch.object(GdriveDataSource, "validate_config")
+    def test_load_pdf_file(self, mock_validate, mock_service):
+        mock_svc = MagicMock()
+        mock_service.return_value = mock_svc
+
+        # Mock list files
+        mock_svc.files().list().execute.return_value = {
+            "files": [{
+                "id": "file1",
+                "name": "test.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2026-01-01T00:00:00Z",
+            }]
+        }
+
+        # Mock file download
+        mock_svc.files().get_media().execute.return_value = b"fake pdf content"
+
+        source = GdriveDataSource({"type": "gdrive", "folder_id": "folder1"})
+
+        with patch.object(source, "_extract_pdf") as mock_extract:
+            from langchain_core.documents import Document
+            mock_extract.return_value = [
+                Document(page_content="PDF text", metadata={"source": "gdrive://file1"})
+            ]
+            docs = source.load()
+
+        assert len(docs) == 1
+        assert docs[0].page_content == "PDF text"
+
+    @patch.object(GdriveDataSource, "_build_service")
+    @patch.object(GdriveDataSource, "validate_config")
+    def test_load_skips_unsupported_files(self, mock_validate, mock_service):
+        mock_svc = MagicMock()
+        mock_service.return_value = mock_svc
+
+        mock_svc.files().list().execute.return_value = {
+            "files": [{
+                "id": "file1",
+                "name": "image.png",
+                "mimeType": "image/png",
+                "modifiedTime": "2026-01-01T00:00:00Z",
+            }]
+        }
+
+        source = GdriveDataSource({"type": "gdrive", "folder_id": "folder1"})
+        docs = source.load()
+        assert len(docs) == 0
+
+
+class TestGdriveHealthCheck:
+    @patch.object(GdriveDataSource, "_build_service")
+    @patch.object(GdriveDataSource, "validate_config")
+    def test_health_check_passes(self, mock_validate, mock_service):
+        mock_svc = MagicMock()
+        mock_service.return_value = mock_svc
+        mock_svc.files().list().execute.return_value = {"files": []}
+
+        source = GdriveDataSource({"type": "gdrive", "folder_id": "folder1"})
+        assert source.health_check() is True
+
+    @patch.object(GdriveDataSource, "_build_service")
+    @patch.object(GdriveDataSource, "validate_config")
+    def test_health_check_fails(self, mock_validate, mock_service):
+        mock_svc = MagicMock()
+        mock_service.return_value = mock_svc
+        mock_svc.files().list().execute.side_effect = Exception("API error")
+
+        source = GdriveDataSource({"type": "gdrive", "folder_id": "folder1"})
+        with pytest.raises(ConnectionError, match="Cannot access"):
+            source.health_check()

--- a/tests/test_data_sources/test_huggingface.py
+++ b/tests/test_data_sources/test_huggingface.py
@@ -1,0 +1,118 @@
+"""Tests for HuggingFace data source connector."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.data_sources.huggingface import HuggingFaceDataSource
+
+
+class TestHuggingFaceValidateConfig:
+    def test_missing_dataset_name(self):
+        source = HuggingFaceDataSource({"type": "huggingface"})
+        with pytest.raises(ValueError, match="dataset_name"):
+            source.validate_config()
+
+    def test_missing_split(self):
+        source = HuggingFaceDataSource({"type": "huggingface", "dataset_name": "squad"})
+        with pytest.raises(ValueError, match="split"):
+            source.validate_config()
+
+    def test_valid_config(self):
+        source = HuggingFaceDataSource({
+            "type": "huggingface", "dataset_name": "squad", "split": "validation"
+        })
+        assert source.validate_config() is True
+
+
+class TestHuggingFaceLoadWithQa:
+    def test_squad_extraction(self):
+        mock_datasets = MagicMock()
+        mock_ds = MagicMock()
+        mock_ds.__len__ = MagicMock(return_value=3)
+        mock_ds.__iter__ = MagicMock(return_value=iter([
+            {"context": "Paris is the capital of France.", "question": "What is the capital of France?", "answers": {"text": ["Paris"]}},
+            {"context": "Paris is the capital of France.", "question": "Where is the Eiffel Tower?", "answers": {"text": ["Paris"]}},
+            {"context": "Berlin is the capital of Germany.", "question": "What is the capital of Germany?", "answers": {"text": ["Berlin"]}},
+        ]))
+        mock_ds.select = MagicMock(return_value=mock_ds)
+        mock_datasets.load_dataset.return_value = mock_ds
+
+        with patch.dict(sys.modules, {"datasets": mock_datasets}):
+            source = HuggingFaceDataSource({
+                "type": "huggingface", "dataset_name": "squad", "split": "validation"
+            })
+            docs, qa_pairs = source.load_with_qa()
+
+        # 2 unique contexts
+        assert len(docs) == 2
+        # 3 QA pairs
+        assert len(qa_pairs) == 3
+        assert qa_pairs[0]["question"] == "What is the capital of France?"
+        assert qa_pairs[0]["ground_truth"] == "Paris"
+
+    def test_sample_size_limit(self):
+        mock_datasets = MagicMock()
+        mock_ds = MagicMock()
+        mock_ds.__len__ = MagicMock(return_value=100)
+
+        # After select, return 5 items
+        selected_ds = MagicMock()
+        selected_ds.__len__ = MagicMock(return_value=5)
+        selected_ds.__iter__ = MagicMock(return_value=iter([
+            {"context": f"ctx{i}", "question": f"q{i}", "answers": {"text": [f"a{i}"]}}
+            for i in range(5)
+        ]))
+        mock_ds.select.return_value = selected_ds
+        mock_datasets.load_dataset.return_value = mock_ds
+
+        with patch.dict(sys.modules, {"datasets": mock_datasets}):
+            source = HuggingFaceDataSource({
+                "type": "huggingface", "dataset_name": "squad",
+                "split": "validation", "sample_size": 5,
+            })
+            docs, qa_pairs = source.load_with_qa()
+
+        mock_ds.select.assert_called_once_with(range(5))
+        assert len(qa_pairs) == 5
+
+    def test_load_returns_only_documents(self):
+        mock_datasets = MagicMock()
+        mock_ds = MagicMock()
+        mock_ds.__len__ = MagicMock(return_value=1)
+        mock_ds.__iter__ = MagicMock(return_value=iter([
+            {"context": "test", "question": "q?", "answers": {"text": ["a"]}},
+        ]))
+        mock_datasets.load_dataset.return_value = mock_ds
+
+        with patch.dict(sys.modules, {"datasets": mock_datasets}):
+            source = HuggingFaceDataSource({
+                "type": "huggingface", "dataset_name": "squad", "split": "validation"
+            })
+            docs = source.load()
+
+        assert len(docs) == 1
+        assert isinstance(docs, list)
+
+
+class TestHuggingFaceHealthCheck:
+    def test_health_check_passes(self):
+        mock_datasets = MagicMock()
+
+        with patch.dict(sys.modules, {"datasets": mock_datasets}):
+            source = HuggingFaceDataSource({
+                "type": "huggingface", "dataset_name": "squad", "split": "validation"
+            })
+            assert source.health_check() is True
+
+    def test_health_check_fails(self):
+        mock_datasets = MagicMock()
+        mock_datasets.load_dataset_builder.side_effect = Exception("not found")
+
+        with patch.dict(sys.modules, {"datasets": mock_datasets}):
+            source = HuggingFaceDataSource({
+                "type": "huggingface", "dataset_name": "nonexistent", "split": "train"
+            })
+            with pytest.raises(ConnectionError, match="Cannot access"):
+                source.health_check()

--- a/tests/test_data_sources/test_notion.py
+++ b/tests/test_data_sources/test_notion.py
@@ -1,0 +1,116 @@
+"""Tests for Notion data source connector."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.data_sources.notion import NotionDataSource
+
+
+class TestNotionValidateConfig:
+    def test_missing_database_id(self):
+        source = NotionDataSource({"type": "notion"})
+        with pytest.raises(ValueError, match="database_id"):
+            source.validate_config()
+
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("NOTION_API_KEY", raising=False)
+        source = NotionDataSource({"type": "notion", "database_id": "abc"})
+        with pytest.raises(ValueError, match="NOTION_API_KEY"):
+            source.validate_config()
+
+    def test_valid_config(self, monkeypatch):
+        monkeypatch.setenv("NOTION_API_KEY", "ntn_test")
+        source = NotionDataSource({"type": "notion", "database_id": "abc"})
+        assert source.validate_config() is True
+
+
+class TestNotionLoad:
+    @patch("src.data_sources.notion.requests")
+    def test_load_pages(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("NOTION_API_KEY", "ntn_test")
+
+        # Mock database query
+        query_resp = MagicMock()
+        query_resp.status_code = 200
+        query_resp.json.return_value = {
+            "results": [{
+                "id": "page1",
+                "last_edited_time": "2026-01-01T00:00:00Z",
+                "properties": {
+                    "Name": {"type": "title", "title": [{"plain_text": "Test Page"}]},
+                },
+            }],
+            "has_more": False,
+        }
+
+        # Mock block children
+        blocks_resp = MagicMock()
+        blocks_resp.status_code = 200
+        blocks_resp.json.return_value = {
+            "results": [{
+                "type": "paragraph",
+                "paragraph": {"rich_text": [{"plain_text": "Hello from Notion"}]},
+                "has_children": False,
+            }],
+            "has_more": False,
+        }
+        blocks_resp.raise_for_status = MagicMock()
+        query_resp.raise_for_status = MagicMock()
+
+        mock_requests.post.return_value = query_resp
+        mock_requests.get.side_effect = [MagicMock(status_code=200), blocks_resp]
+
+        source = NotionDataSource({"type": "notion", "database_id": "db1"})
+
+        # Mock health check's GET
+        with patch.object(source, "validate_config"):
+            docs = source.load()
+
+        assert len(docs) == 1
+        assert "Hello from Notion" in docs[0].page_content
+        assert docs[0].metadata["title"] == "Test Page"
+
+
+class TestNotionExtractText:
+    def test_extract_various_block_types(self, monkeypatch):
+        monkeypatch.setenv("NOTION_API_KEY", "ntn_test")
+        source = NotionDataSource({"type": "notion", "database_id": "db1"})
+
+        blocks = [
+            {"type": "heading_1", "heading_1": {"rich_text": [{"plain_text": "Title"}]}, "has_children": False},
+            {"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": "Body text"}]}, "has_children": False},
+            {"type": "bulleted_list_item", "bulleted_list_item": {"rich_text": [{"plain_text": "Item 1"}]}, "has_children": False},
+            {"type": "code", "code": {"rich_text": [{"plain_text": "print('hi')"}]}, "has_children": False},
+        ]
+
+        text = source._extract_text({}, blocks)
+        assert "# Title" in text
+        assert "Body text" in text
+        assert "- Item 1" in text
+        assert "print('hi')" in text
+
+
+class TestNotionHealthCheck:
+    @patch("src.data_sources.notion.requests")
+    def test_health_check_passes(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("NOTION_API_KEY", "ntn_test")
+        resp = MagicMock()
+        resp.status_code = 200
+        mock_requests.get.return_value = resp
+
+        source = NotionDataSource({"type": "notion", "database_id": "db1"})
+        assert source.health_check() is True
+
+    @patch("src.data_sources.notion.requests")
+    def test_health_check_fails(self, mock_requests, monkeypatch):
+        monkeypatch.setenv("NOTION_API_KEY", "ntn_test")
+        resp = MagicMock()
+        resp.status_code = 401
+        resp.text = "Unauthorized"
+        mock_requests.get.return_value = resp
+
+        source = NotionDataSource({"type": "notion", "database_id": "db1"})
+        with pytest.raises(ConnectionError, match="Cannot access"):
+            source.health_check()

--- a/tests/test_data_sources/test_registry.py
+++ b/tests/test_data_sources/test_registry.py
@@ -57,15 +57,8 @@ class TestRegistry:
         with pytest.raises(ValueError, match="missing 'type' field"):
             get_data_source({})
 
-    def test_stubs_raise_not_implemented(self):
-        """Stub connectors raise NotImplementedError for all methods."""
+    def test_implemented_connectors_have_load(self):
+        """Implemented connectors have working load/validate_config methods."""
         source = get_data_source({"type": "local_pdf", "path": "data/pdfs/"})
-
-        with pytest.raises(NotImplementedError):
-            source.load()
-
-        with pytest.raises(NotImplementedError):
-            source.validate_config()
-
-        with pytest.raises(NotImplementedError):
-            source.health_check()
+        # validate_config should work (path is set)
+        assert source.validate_config() is True

--- a/tests/test_data_sources/test_s3.py
+++ b/tests/test_data_sources/test_s3.py
@@ -1,0 +1,120 @@
+"""Tests for S3 data source connector."""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.data_sources.s3 import S3DataSource
+
+
+class TestS3ValidateConfig:
+    def test_missing_bucket(self):
+        source = S3DataSource({"type": "s3"})
+        with pytest.raises(ValueError, match="bucket"):
+            source.validate_config()
+
+    def test_missing_aws_key(self, monkeypatch):
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        source = S3DataSource({"type": "s3", "bucket": "my-bucket"})
+        with pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID"):
+            source.validate_config()
+
+    def test_missing_aws_secret(self, monkeypatch):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        source = S3DataSource({"type": "s3", "bucket": "my-bucket"})
+        with pytest.raises(ValueError, match="AWS_SECRET_ACCESS_KEY"):
+            source.validate_config()
+
+    def test_valid_config(self, monkeypatch):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        source = S3DataSource({"type": "s3", "bucket": "my-bucket"})
+        assert source.validate_config() is True
+
+
+class TestS3Load:
+    @patch.object(S3DataSource, "_get_client")
+    @patch.object(S3DataSource, "validate_config")
+    def test_load_txt_files(self, mock_validate, mock_client):
+        client = MagicMock()
+        mock_client.return_value = client
+
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{
+            "Contents": [
+                {"Key": "docs/file1.txt", "LastModified": "2026-01-01"},
+            ]
+        }]
+        client.get_paginator.return_value = paginator
+
+        source = S3DataSource({"type": "s3", "bucket": "test-bucket", "prefix": "docs/"})
+
+        with patch.object(source, "_process_file") as mock_process:
+            from langchain_core.documents import Document
+            mock_process.return_value = [
+                Document(page_content="text content", metadata={"source_type": "s3"})
+            ]
+            docs = source.load()
+
+        assert len(docs) == 1
+
+    @patch.object(S3DataSource, "_get_client")
+    @patch.object(S3DataSource, "validate_config")
+    def test_load_skips_unsupported(self, mock_validate, mock_client):
+        client = MagicMock()
+        mock_client.return_value = client
+
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{
+            "Contents": [
+                {"Key": "docs/image.png", "LastModified": "2026-01-01"},
+            ]
+        }]
+        client.get_paginator.return_value = paginator
+
+        source = S3DataSource({"type": "s3", "bucket": "test-bucket"})
+        docs = source.load()
+        assert len(docs) == 0
+
+    def test_extract_txt(self, tmp_path):
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Hello world", encoding="utf-8")
+
+        source = S3DataSource({"type": "s3", "bucket": "b"})
+        docs = source._extract_txt(str(txt_file), "b", {"Key": "test.txt", "LastModified": ""})
+        assert len(docs) == 1
+        assert docs[0].page_content == "Hello world"
+        assert docs[0].metadata["source_type"] == "s3"
+
+    def test_extract_txt_empty(self, tmp_path):
+        txt_file = tmp_path / "empty.txt"
+        txt_file.write_text("", encoding="utf-8")
+
+        source = S3DataSource({"type": "s3", "bucket": "b"})
+        docs = source._extract_txt(str(txt_file), "b", {"Key": "empty.txt"})
+        assert len(docs) == 0
+
+
+class TestS3HealthCheck:
+    @patch.object(S3DataSource, "_get_client")
+    @patch.object(S3DataSource, "validate_config")
+    def test_health_check_passes(self, mock_validate, mock_client):
+        client = MagicMock()
+        mock_client.return_value = client
+
+        source = S3DataSource({"type": "s3", "bucket": "test-bucket"})
+        assert source.health_check() is True
+
+    @patch.object(S3DataSource, "_get_client")
+    @patch.object(S3DataSource, "validate_config")
+    def test_health_check_fails(self, mock_validate, mock_client):
+        client = MagicMock()
+        client.head_bucket.side_effect = Exception("access denied")
+        mock_client.return_value = client
+
+        source = S3DataSource({"type": "s3", "bucket": "bad-bucket"})
+        with pytest.raises(ConnectionError, match="Cannot access"):
+            source.health_check()

--- a/tests/test_data_sources/test_web.py
+++ b/tests/test_data_sources/test_web.py
@@ -1,0 +1,99 @@
+"""Tests for web data source connector."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.data_sources.web import WebDataSource
+
+
+class TestWebValidateConfig:
+    def test_missing_urls(self):
+        source = WebDataSource({"type": "web"})
+        with pytest.raises(ValueError, match="urls"):
+            source.validate_config()
+
+    def test_empty_urls(self):
+        source = WebDataSource({"type": "web", "urls": []})
+        with pytest.raises(ValueError, match="urls"):
+            source.validate_config()
+
+    def test_valid_config(self):
+        source = WebDataSource({"type": "web", "urls": ["https://example.com"]})
+        assert source.validate_config() is True
+
+
+class TestWebLoad:
+    @patch("src.data_sources.web.requests")
+    @patch.object(WebDataSource, "_check_robots", return_value=True)
+    def test_load_extracts_content(self, mock_robots, mock_requests):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = """
+        <html>
+        <head><title>Test Page</title></head>
+        <body>
+            <nav>Navigation</nav>
+            <main><p>Main content here</p></main>
+            <footer>Footer</footer>
+        </body>
+        </html>
+        """
+        resp.raise_for_status = MagicMock()
+        mock_requests.get.return_value = resp
+
+        source = WebDataSource({"type": "web", "urls": ["https://example.com"]})
+        docs = source.load()
+
+        assert len(docs) == 1
+        assert "Main content" in docs[0].page_content
+        assert "Navigation" not in docs[0].page_content
+        assert "Footer" not in docs[0].page_content
+        assert docs[0].metadata["page_title"] == "Test Page"
+
+    @patch("src.data_sources.web.requests")
+    @patch.object(WebDataSource, "_check_robots", return_value=True)
+    def test_load_handles_timeout(self, mock_robots, mock_requests):
+        import requests
+        mock_requests.get.side_effect = requests.Timeout("timeout")
+        mock_requests.Timeout = requests.Timeout
+
+        source = WebDataSource({"type": "web", "urls": ["https://slow.example.com"]})
+        docs = source.load()
+        assert len(docs) == 0
+
+    @patch("src.data_sources.web.requests")
+    @patch.object(WebDataSource, "_check_robots", return_value=False)
+    def test_load_respects_robots(self, mock_robots, mock_requests):
+        source = WebDataSource({"type": "web", "urls": ["https://blocked.example.com"]})
+        docs = source.load()
+        assert len(docs) == 0
+        mock_requests.get.assert_not_called()
+
+    @patch("src.data_sources.web.requests")
+    @patch.object(WebDataSource, "_check_robots", return_value=True)
+    def test_load_handles_failed_url(self, mock_robots, mock_requests):
+        mock_requests.get.side_effect = Exception("connection error")
+
+        source = WebDataSource({"type": "web", "urls": ["https://bad.example.com"]})
+        docs = source.load()
+        assert len(docs) == 0
+
+
+class TestWebHealthCheck:
+    @patch("src.data_sources.web.requests")
+    def test_health_check_passes(self, mock_requests):
+        resp = MagicMock()
+        resp.status_code = 200
+        mock_requests.head.return_value = resp
+
+        source = WebDataSource({"type": "web", "urls": ["https://example.com"]})
+        assert source.health_check() is True
+
+    @patch("src.data_sources.web.requests")
+    def test_health_check_fails(self, mock_requests):
+        mock_requests.head.side_effect = Exception("unreachable")
+
+        source = WebDataSource({"type": "web", "urls": ["https://bad.example.com"]})
+        with pytest.raises(ConnectionError, match="None of the configured URLs"):
+            source.health_check()


### PR DESCRIPTION
## Summary
- Implement gdrive, s3, notion, web, and huggingface data source connectors
- Each connector has full load/validate_config/health_check implementations
- Fix registry `_ensure_registered` for test ordering reliability
- Comprehensive mock-based test suites for all connectors

## Test plan
- [x] All connector tests pass with mocked external APIs
- [x] Registry test verifies all 8 connector types registered
- [x] Config validation catches missing credentials/fields
- [x] Health check failures are reported clearly

Closes #8, #9, #10, #11, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)