### PR TITLE
Implement dataset_loader orchestrator

### DIFF
--- a/src/dataset_loader.py
+++ b/src/dataset_loader.py
@@ -1,0 +1,93 @@
+"""Dataset loader that orchestrates all enabled data sources."""
+
+import hashlib
+import logging
+from typing import List, Optional
+
+from langchain_core.documents import Document
+
+from src.data_sources import get_data_source
+
+logger = logging.getLogger(__name__)
+
+
+def _content_hash(text: str) -> str:
+    """Compute MD5 hash of document content for deduplication."""
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+
+def load_documents(
+    data_source_configs: list[dict],
+) -> tuple[List[Document], Optional[List[dict]]]:
+    """Load and merge documents from all enabled data sources.
+
+    Args:
+        data_source_configs: List of data source config dicts, each with at
+            least a 'type' key and an 'enabled' key.
+
+    Returns:
+        Tuple of (documents, qa_pairs). qa_pairs is None unless a huggingface
+        connector is enabled and returns QA pairs.
+    """
+    all_documents: List[Document] = []
+    all_qa_pairs: Optional[List[dict]] = None
+
+    enabled_configs = [c for c in data_source_configs if c.get("enabled", False)]
+    if not enabled_configs:
+        logger.warning("No enabled data sources found")
+        return [], None
+
+    # Health check all sources first
+    sources = []
+    for config in enabled_configs:
+        try:
+            source = get_data_source(config)
+            source.health_check()
+            sources.append((config, source))
+        except Exception as e:
+            logger.error(
+                "Health check failed for %s: %s — skipping",
+                config.get("type", "unknown"), e,
+            )
+
+    if not sources:
+        logger.error("All data source health checks failed")
+        return [], None
+
+    # Load from each source
+    for config, source in sources:
+        source_type = config.get("type", "unknown")
+        try:
+            # Special handling for huggingface: collect QA pairs
+            if source_type == "huggingface" and hasattr(source, "load_with_qa"):
+                docs, qa_pairs = source.load_with_qa()
+                if qa_pairs:
+                    all_qa_pairs = (all_qa_pairs or []) + qa_pairs
+            else:
+                docs = source.load()
+
+            logger.info("Loaded %d documents from %s", len(docs), source_type)
+            all_documents.extend(docs)
+        except Exception as e:
+            logger.error("Failed to load from %s: %s — continuing", source_type, e)
+
+    # Deduplicate by content hash
+    seen_hashes: set[str] = set()
+    unique_documents: List[Document] = []
+    for doc in all_documents:
+        h = _content_hash(doc.page_content)
+        if h not in seen_hashes:
+            seen_hashes.add(h)
+            unique_documents.append(doc)
+
+    deduped = len(all_documents) - len(unique_documents)
+    if deduped > 0:
+        logger.info("Deduplicated %d documents (removed %d duplicates)", len(unique_documents), deduped)
+
+    logger.info(
+        "Total: %d documents from %d sources%s",
+        len(unique_documents),
+        len(sources),
+        f", {len(all_qa_pairs)} QA pairs" if all_qa_pairs else "",
+    )
+    return unique_documents, all_qa_pairs

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,0 +1,119 @@
+"""Tests for dataset_loader module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.documents import Document
+
+from src.dataset_loader import _content_hash, load_documents
+
+
+class TestContentHash:
+    def test_same_content_same_hash(self):
+        assert _content_hash("hello") == _content_hash("hello")
+
+    def test_different_content_different_hash(self):
+        assert _content_hash("hello") != _content_hash("world")
+
+
+class TestLoadDocuments:
+    @patch("src.dataset_loader.get_data_source")
+    def test_load_from_single_source(self, mock_get_ds):
+        mock_source = MagicMock()
+        mock_source.load.return_value = [
+            Document(page_content="doc1", metadata={"source": "test"}),
+            Document(page_content="doc2", metadata={"source": "test"}),
+        ]
+        mock_get_ds.return_value = mock_source
+
+        configs = [{"type": "local_txt", "enabled": True, "path": "/data"}]
+        docs, qa_pairs = load_documents(configs)
+
+        assert len(docs) == 2
+        assert qa_pairs is None
+
+    @patch("src.dataset_loader.get_data_source")
+    def test_load_from_multiple_sources(self, mock_get_ds):
+        mock_source1 = MagicMock()
+        mock_source1.load.return_value = [
+            Document(page_content="doc1", metadata={"source": "src1"}),
+        ]
+        mock_source2 = MagicMock()
+        mock_source2.load.return_value = [
+            Document(page_content="doc2", metadata={"source": "src2"}),
+        ]
+        mock_get_ds.side_effect = [mock_source1, mock_source2]
+
+        configs = [
+            {"type": "local_txt", "enabled": True},
+            {"type": "local_csv", "enabled": True},
+        ]
+        docs, _ = load_documents(configs)
+        assert len(docs) == 2
+
+    @patch("src.dataset_loader.get_data_source")
+    def test_deduplication(self, mock_get_ds):
+        mock_source = MagicMock()
+        mock_source.load.return_value = [
+            Document(page_content="same content", metadata={"source": "a"}),
+            Document(page_content="same content", metadata={"source": "b"}),
+            Document(page_content="different", metadata={"source": "c"}),
+        ]
+        mock_get_ds.return_value = mock_source
+
+        configs = [{"type": "local_txt", "enabled": True}]
+        docs, _ = load_documents(configs)
+        assert len(docs) == 2
+
+    @patch("src.dataset_loader.get_data_source")
+    def test_graceful_failure_one_source(self, mock_get_ds):
+        mock_source1 = MagicMock()
+        mock_source1.load.side_effect = RuntimeError("source1 crashed")
+        mock_source2 = MagicMock()
+        mock_source2.load.return_value = [
+            Document(page_content="doc", metadata={"source": "ok"}),
+        ]
+        mock_get_ds.side_effect = [mock_source1, mock_source2]
+
+        configs = [
+            {"type": "bad", "enabled": True},
+            {"type": "good", "enabled": True},
+        ]
+        docs, _ = load_documents(configs)
+        assert len(docs) == 1
+
+    @patch("src.dataset_loader.get_data_source")
+    def test_health_check_failure_skips_source(self, mock_get_ds):
+        mock_source = MagicMock()
+        mock_source.health_check.side_effect = ConnectionError("no access")
+        mock_get_ds.return_value = mock_source
+
+        configs = [{"type": "bad", "enabled": True}]
+        docs, _ = load_documents(configs)
+        assert len(docs) == 0
+
+    def test_no_enabled_sources(self):
+        configs = [{"type": "local_txt", "enabled": False}]
+        docs, qa_pairs = load_documents(configs)
+        assert docs == []
+        assert qa_pairs is None
+
+    def test_empty_configs(self):
+        docs, qa_pairs = load_documents([])
+        assert docs == []
+        assert qa_pairs is None
+
+    @patch("src.dataset_loader.get_data_source")
+    def test_huggingface_qa_pairs(self, mock_get_ds):
+        mock_source = MagicMock()
+        mock_source.load_with_qa.return_value = (
+            [Document(page_content="ctx", metadata={"source": "hf"})],
+            [{"question": "Q?", "ground_truth": "A"}],
+        )
+        mock_get_ds.return_value = mock_source
+
+        configs = [{"type": "huggingface", "enabled": True}]
+        docs, qa_pairs = load_documents(configs)
+        assert len(docs) == 1
+        assert len(qa_pairs) == 1
+        assert qa_pairs[0]["question"] == "Q?"


### PR DESCRIPTION
## Summary
- Orchestrates all enabled data sources, merges documents
- Deduplicates documents by MD5 content hash
- Graceful failure handling (skip failed sources, continue)
- Special handling for huggingface QA pair extraction

## Test plan
- [x] Load from single and multiple mock sources
- [x] Deduplication removes duplicate content
- [x] Failed source does not crash the loader
- [x] HuggingFace QA pairs collected correctly

Closes #13