### PR TITLE
Implement LLM agent for config suggestion

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -1,0 +1,187 @@
+"""LLM agent for config suggestion with reasoning chain.
+
+The agent reads experiment history and search space constraints,
+then writes a new experiment_config.json and appends reasoning to agent_notes.md.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _load_history(history_path: Path) -> list[dict]:
+    """Load experiment history from JSONL file."""
+    if not history_path.exists():
+        return []
+    entries = []
+    for line in history_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            entries.append(json.loads(line))
+    return entries
+
+
+def _build_prompt(search_space: dict, history: list[dict], current_scores: dict) -> str:
+    """Build the agent prompt for suggesting the next config."""
+    history_text = ""
+    if history:
+        for entry in history:
+            cfg = entry.get("config", {})
+            scores = entry.get("scores", {})
+            history_text += (
+                f"  Iteration {entry.get('iteration', '?')}: "
+                f"composite={entry.get('composite_score', '?'):.4f} | "
+                f"config={json.dumps(cfg)} | "
+                f"scores={json.dumps({k: round(v, 4) if isinstance(v, float) else v for k, v in scores.items()})}\n"
+            )
+    else:
+        history_text = "  (no previous experiments)\n"
+
+    tried_configs = [json.dumps(e.get("config", {}), sort_keys=True) for e in history]
+    tried_text = "\n".join(f"  - {c}" for c in tried_configs) if tried_configs else "  (none)"
+
+    return f"""You are an AI research agent optimizing a RAG pipeline. Analyze the experiment history and suggest the next configuration to try.
+
+## Search Space Constraints
+{json.dumps(search_space, indent=2)}
+
+## Experiment History
+{history_text}
+
+## Current Scores
+{json.dumps({k: round(v, 4) if isinstance(v, float) else v for k, v in current_scores.items()}, indent=2)}
+
+## Already Tried Configs (DO NOT repeat these)
+{tried_text}
+
+## Instructions
+1. Analyze which metric is weakest and why
+2. Reason about which hyperparameters would improve the weakest metric
+3. Suggest a NEW config that has NOT been tried before
+4. All values must be within the search space constraints
+
+Respond in this exact JSON format:
+{{
+  "analysis": "Your analysis of the weakest metric and why...",
+  "decision": "Your reasoning for the next config choice...",
+  "config": {{
+    "chunk_size": <int>,
+    "chunk_overlap": <int>,
+    "top_k": <int>,
+    "embedding_model": "<string>",
+    "llm_model": "<string>"
+  }}
+}}"""
+
+
+def _validate_config(config: dict, search_space: dict) -> bool:
+    """Validate that config values are within the search space."""
+    for key, allowed in search_space.items():
+        if key in config:
+            if config[key] not in allowed:
+                raise ValueError(
+                    f"Config {key}={config[key]} not in allowed values: {allowed}"
+                )
+    return True
+
+
+def _is_duplicate(config: dict, history: list[dict]) -> bool:
+    """Check if a config has already been tried."""
+    config_str = json.dumps(config, sort_keys=True)
+    for entry in history:
+        if json.dumps(entry.get("config", {}), sort_keys=True) == config_str:
+            return True
+    return False
+
+
+def suggest_next_config(
+    history_path: str | Path,
+    search_space: dict,
+    current_scores: dict,
+    config_output_path: str | Path = "experiment_config.json",
+    notes_path: str | Path = "agent_notes.md",
+    llm_model: str = "gpt-4o-mini",
+    max_retries: int = 3,
+) -> dict:
+    """Use an LLM to suggest the next experiment config.
+
+    Args:
+        history_path: Path to experiment_history.jsonl.
+        search_space: Dict mapping param names to lists of allowed values.
+        current_scores: Current RAGAS scores dict.
+        config_output_path: Where to write experiment_config.json.
+        notes_path: Where to append agent reasoning (agent_notes.md).
+        llm_model: LLM to use for the agent.
+        max_retries: Max attempts if agent suggests duplicate/invalid config.
+
+    Returns:
+        The suggested config dict.
+    """
+    from openai import OpenAI
+
+    history_path = Path(history_path)
+    config_output_path = Path(config_output_path)
+    notes_path = Path(notes_path)
+
+    history = _load_history(history_path)
+    iteration = len(history) + 1
+
+    client = OpenAI()
+
+    for attempt in range(max_retries):
+        prompt = _build_prompt(search_space, history, current_scores)
+
+        if attempt > 0:
+            prompt += f"\n\nNOTE: Your previous suggestion was rejected (attempt {attempt + 1}/{max_retries}). Pick a DIFFERENT config."
+
+        response = client.chat.completions.create(
+            model=llm_model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+            response_format={"type": "json_object"},
+        )
+
+        raw = response.choices[0].message.content
+        parsed = json.loads(raw)
+        config = parsed["config"]
+        analysis = parsed.get("analysis", "")
+        decision = parsed.get("decision", "")
+
+        # Validate
+        try:
+            _validate_config(config, search_space)
+        except ValueError as e:
+            logger.warning("Agent suggested invalid config (attempt %d): %s", attempt + 1, e)
+            continue
+
+        if _is_duplicate(config, history):
+            logger.warning("Agent suggested duplicate config (attempt %d)", attempt + 1)
+            continue
+
+        # Write experiment_config.json
+        config_output_path.write_text(
+            json.dumps(config, indent=2) + "\n", encoding="utf-8"
+        )
+        logger.info("Wrote next config to %s", config_output_path)
+
+        # Append to agent_notes.md
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+        notes_entry = (
+            f"\n## Iteration {iteration} \u2014 {timestamp}\n"
+            f"### Analysis\n{analysis}\n\n"
+            f"### Decision\n{decision}\n\n"
+            f"### Next Config\n"
+            f"{', '.join(f'{k}={v}' for k, v in config.items())}\n"
+        )
+        with open(notes_path, "a", encoding="utf-8") as f:
+            f.write(notes_entry)
+        logger.info("Appended reasoning to %s", notes_path)
+
+        return config
+
+    raise RuntimeError(
+        f"Agent failed to suggest a valid, non-duplicate config after {max_retries} attempts"
+    )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,202 @@
+"""Tests for agent module."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agent import (
+    _is_duplicate,
+    _load_history,
+    _validate_config,
+)
+
+SEARCH_SPACE = {
+    "chunk_size": [256, 512, 1024],
+    "chunk_overlap": [25, 50, 100],
+    "top_k": [3, 5, 10],
+    "embedding_model": ["all-MiniLM-L6-v2", "BGE-large", "text-embedding-ada-002"],
+    "llm_model": ["gpt-4o-mini", "gpt-3.5-turbo"],
+}
+
+SAMPLE_CONFIG = {
+    "chunk_size": 512,
+    "chunk_overlap": 50,
+    "top_k": 5,
+    "embedding_model": "all-MiniLM-L6-v2",
+    "llm_model": "gpt-4o-mini",
+}
+
+
+class TestLoadHistory:
+    def test_load_empty_file(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        path.write_text("")
+        assert _load_history(path) == []
+
+    def test_load_nonexistent_file(self, tmp_path):
+        path = tmp_path / "nonexistent.jsonl"
+        assert _load_history(path) == []
+
+    def test_load_valid_history(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        entries = [
+            {"iteration": 1, "config": SAMPLE_CONFIG, "composite_score": 0.75},
+            {"iteration": 2, "config": SAMPLE_CONFIG, "composite_score": 0.80},
+        ]
+        path.write_text("\n".join(json.dumps(e) for e in entries))
+        result = _load_history(path)
+        assert len(result) == 2
+        assert result[0]["iteration"] == 1
+
+
+class TestValidateConfig:
+    def test_valid_config(self):
+        assert _validate_config(SAMPLE_CONFIG, SEARCH_SPACE) is True
+
+    def test_invalid_chunk_size(self):
+        config = {**SAMPLE_CONFIG, "chunk_size": 999}
+        with pytest.raises(ValueError, match="chunk_size=999 not in allowed"):
+            _validate_config(config, SEARCH_SPACE)
+
+    def test_invalid_embedding_model(self):
+        config = {**SAMPLE_CONFIG, "embedding_model": "nonexistent"}
+        with pytest.raises(ValueError, match="embedding_model"):
+            _validate_config(config, SEARCH_SPACE)
+
+
+class TestIsDuplicate:
+    def test_not_duplicate(self):
+        history = [{"config": SAMPLE_CONFIG}]
+        different = {**SAMPLE_CONFIG, "chunk_size": 256}
+        assert _is_duplicate(different, history) is False
+
+    def test_is_duplicate(self):
+        history = [{"config": SAMPLE_CONFIG}]
+        assert _is_duplicate(SAMPLE_CONFIG, history) is True
+
+    def test_empty_history(self):
+        assert _is_duplicate(SAMPLE_CONFIG, []) is False
+
+
+def _make_mock_openai(config_to_return):
+    """Create a mock openai module with a client that returns the given config."""
+    mock_openai_module = MagicMock()
+    mock_client = MagicMock()
+    mock_openai_module.OpenAI.return_value = mock_client
+
+    response = MagicMock()
+    response.choices = [
+        MagicMock(
+            message=MagicMock(
+                content=json.dumps({
+                    "analysis": "Context recall is weakest.",
+                    "decision": "Increase top_k and use BGE-large.",
+                    "config": config_to_return,
+                })
+            )
+        )
+    ]
+    mock_client.chat.completions.create.return_value = response
+    return mock_openai_module, mock_client
+
+
+class TestSuggestNextConfig:
+    def test_suggest_writes_config_and_notes(self, tmp_path):
+        new_config = {
+            "chunk_size": 256,
+            "chunk_overlap": 50,
+            "top_k": 10,
+            "embedding_model": "BGE-large",
+            "llm_model": "gpt-4o-mini",
+        }
+        mock_openai_module, _ = _make_mock_openai(new_config)
+
+        history_path = tmp_path / "history.jsonl"
+        history_path.write_text(
+            json.dumps({"iteration": 1, "config": SAMPLE_CONFIG, "scores": {}, "composite_score": 0.75})
+        )
+        config_path = tmp_path / "experiment_config.json"
+        notes_path = tmp_path / "agent_notes.md"
+
+        with patch.dict(sys.modules, {"openai": mock_openai_module}):
+            from src.agent import suggest_next_config
+
+            result = suggest_next_config(
+                history_path=history_path,
+                search_space=SEARCH_SPACE,
+                current_scores={"faithfulness": 0.8, "context_recall": 0.6},
+                config_output_path=config_path,
+                notes_path=notes_path,
+            )
+
+        assert result == new_config
+        assert config_path.exists()
+        assert json.loads(config_path.read_text()) == new_config
+        assert notes_path.exists()
+        notes = notes_path.read_text()
+        assert "Iteration 2" in notes
+        assert "Context recall is weakest" in notes
+
+    def test_suggest_rejects_duplicate(self, tmp_path):
+        new_config = {**SAMPLE_CONFIG, "chunk_size": 256}
+
+        mock_openai_module = MagicMock()
+        mock_client = MagicMock()
+        mock_openai_module.OpenAI.return_value = mock_client
+
+        # First call returns duplicate, second returns valid
+        dup_response = MagicMock()
+        dup_response.choices = [
+            MagicMock(message=MagicMock(content=json.dumps({
+                "analysis": "...", "decision": "...", "config": SAMPLE_CONFIG,
+            })))
+        ]
+        valid_response = MagicMock()
+        valid_response.choices = [
+            MagicMock(message=MagicMock(content=json.dumps({
+                "analysis": "...", "decision": "...", "config": new_config,
+            })))
+        ]
+        mock_client.chat.completions.create.side_effect = [dup_response, valid_response]
+
+        history_path = tmp_path / "history.jsonl"
+        history_path.write_text(
+            json.dumps({"iteration": 1, "config": SAMPLE_CONFIG, "composite_score": 0.75})
+        )
+
+        with patch.dict(sys.modules, {"openai": mock_openai_module}):
+            from src.agent import suggest_next_config
+
+            result = suggest_next_config(
+                history_path=history_path,
+                search_space=SEARCH_SPACE,
+                current_scores={},
+                config_output_path=tmp_path / "config.json",
+                notes_path=tmp_path / "notes.md",
+            )
+
+        assert result == new_config
+        assert mock_client.chat.completions.create.call_count == 2
+
+    def test_suggest_fails_after_max_retries(self, tmp_path):
+        invalid_config = {**SAMPLE_CONFIG, "chunk_size": 999}
+        mock_openai_module, _ = _make_mock_openai(invalid_config)
+
+        history_path = tmp_path / "history.jsonl"
+        history_path.write_text("")
+
+        with patch.dict(sys.modules, {"openai": mock_openai_module}):
+            from src.agent import suggest_next_config
+
+            with pytest.raises(RuntimeError, match="failed to suggest"):
+                suggest_next_config(
+                    history_path=history_path,
+                    search_space=SEARCH_SPACE,
+                    current_scores={},
+                    config_output_path=tmp_path / "config.json",
+                    notes_path=tmp_path / "notes.md",
+                    max_retries=2,
+                )


### PR DESCRIPTION
## Summary
- LLM agent reads experiment history and search space constraints
- Suggests next hyperparameter config via GPT-4o-mini
- Writes experiment_config.json and appends reasoning to agent_notes.md
- Validates configs against search space, rejects duplicates, retries

## Test plan
- [x] Agent writes valid config and notes files
- [x] Duplicate configs are rejected and retried
- [x] Invalid configs outside search space are rejected
- [x] Fails gracefully after max retries

Closes #17